### PR TITLE
Dump extensions

### DIFF
--- a/lib/roomer/schema_dumper.rb
+++ b/lib/roomer/schema_dumper.rb
@@ -3,18 +3,19 @@ module Roomer
 
     def dump(stream)
       header(stream)
+      extensions(stream)
       tables(stream)
       views(stream)
       trailer(stream)
       stream
-    end 
+    end
 
     protected
     def header(stream)
       define_params = @version ? ":version => #{@version}" : ""
       stream.puts <<HEADER
 # It's strongly recommended to check this file into your version control system.
-    
+
 Roomer::Schema.define(#{define_params}) do
 
 HEADER


### PR DESCRIPTION
PG extensions aren't being added to schema and that results in
disabled extensions in test environment.

This change adds `#extensions` call, so extensions appear in schema.